### PR TITLE
REP: Add a default namespace

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -1,1 +1,3 @@
 ---
+namespaces:
+- name: portfolio-main


### PR DESCRIPTION
- This is causing the namespace kubeyaml not to apply so we aren't
  getting the correct vars for the pipeline operator which is making the
canary fail to deploy