### PR TITLE
REP-365: Fix pay namespace name

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -2,7 +2,7 @@
 namespaces:
 - name: portfolio-main
 
-- name: pay
+- name: portfolio-pay
   owner: alphagov
   repository: pay-gsp-pipelines
   branch: master


### PR DESCRIPTION
Namespaces need to be prefixed with the cluster name. We should document
this requirement.