### PR TITLE
REP-365: Move pipelines to subdirectory in pay-gsp-pipelines

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -7,4 +7,4 @@ namespaces:
   repository: pay-gsp-pipelines
   branch: master
   requiredApprovalCount: 0
-  path: .
+  path: pipelines


### PR DESCRIPTION
I'm doing this so that we can have other things in the pay-gsp-pipelines
repo that aren't kubeyaml and won't get applied by the
configure-namespace job running kubectl.