### PR TITLE
Implement per-namespace ingress gateway

### DIFF
--- a/config/portfolio-main/ingress-certificate.yaml
+++ b/config/portfolio-main/ingress-certificate.yaml
@@ -1,0 +1,18 @@
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Certificate
+metadata:
+  name: ingress-certificate
+  namespace: portfolio-main
+spec:
+  secretName: istio-ingressgateway-certs
+  dnsNames:
+  - "canary.london.portfolio.govsvc.uk"
+  acme:
+    config:
+    - dns01:
+        provider: route53
+      domains:
+      - "canary.london.portfolio.govsvc.uk"
+  issuerRef:
+    name: letsencrypt-r53
+    kind: ClusterIssuer

--- a/values.yaml
+++ b/values.yaml
@@ -1,6 +1,13 @@
 ---
 namespaces:
 - name: portfolio-main
+  owner: alphagov
+  repository: portfolio-cluster-config
+  branch: master
+  path: config/portfolio-main
+  requiredApprovalCount: 2
+  ingress:
+    enabled: true
 
 - name: portfolio-pay
   owner: alphagov


### PR DESCRIPTION
## What

The world as we know it has changed in alphagov/gsp#463 and we are now
required to have a certificate declaration per namespace, that will
register it's domains with letsencrypt.

This will fix our Canary going red.

## How to review

- Compare with alphagov/verify-cluster-config#52