### PR TITLE
Remove old worker nodes

### DIFF
--- a/cluster.yaml
+++ b/cluster.yaml
@@ -24,7 +24,7 @@ users-version: "master"
 users-path: "users"
 disable-destroy: true
 worker-instance-type: m5d.large
-worker-count: 6
+worker-count: 0
 minimum-workers-per-az-count: 2
 maximum-workers-per-az-count: 4
 ci-worker-instance-type: m5d.large


### PR DESCRIPTION
These have been replaced with nodes in the per-AZ ASGs.
The old nodes have been cordoned and drained.